### PR TITLE
Added Employee file

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -76,6 +76,22 @@ collections: # A list of collections the CMS should be able to edit
       - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
       - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
 
+
+  - name: 'ourEmployees' # Used in routes, ie.: /admin/collections/:slug/edit
+    label: 'Our Employees' # Used in the UI
+    label_singular: 'Our Employees' # Used in the UI, ie: "New Post"
+    description: >
+      This collection is for managing our employees. Each post can be stored as a separate document or grouped based on categories or dates.
+    folder: '_ourEmployees'
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields each document in this collection have
+      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
+      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
+      - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
+
   - name: 'ourSupport' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'Our Support' # Used in the UI
     label_singular: 'Our Support' # Used in the UI, ie: "New Post"


### PR DESCRIPTION
Tried to add a empolyee file.

  - name: 'ourEmployees' # Used in routes, ie.: /admin/collections/:slug/edit
    label: 'Our Employees' # Used in the UI
    label_singular: 'Our Employees' # Used in the UI, ie: "New Post"
    description: >
      This collection is for managing our employees. Each post can be stored as a separate document or grouped based on categories or dates.
    folder: '_ourEmployees'
    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
    create: true # Allow users to create new documents in this collection
    fields: # The fields each document in this collection have
      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
      - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}