### PR TITLE
Childrens collection added

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -76,6 +76,39 @@ collections: # A list of collections the CMS should be able to edit
       - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
       - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
 
+<<<<<<< Updated upstream
+=======
+  - name: 'theChildren' # Used in routes, ie.: /admin/collections/:slug/edit
+    label: 'The Children' # Used in the UI
+    label_singular: 'The Children' # Used in the UI, ie: "New Post"
+    description: >
+      This collection is for managing the stories of the children we represent. Each post can be stored as a separate document or grouped based on categories or dates.
+    folder: '_theChildren'
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields each document in this collection have
+      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
+      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
+      - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
+
+  - name: 'ourEmployees' # Used in routes, ie.: /admin/collections/:slug/edit
+    label: 'Our Employees' # Used in the UI
+    label_singular: 'Our Employees' # Used in the UI, ie: "New Post"
+    description: >
+      This collection is for managing our employees. Each post can be stored as a separate document or grouped based on categories or dates.
+    folder: '_ourEmployees'
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields each document in this collection have
+      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
+      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
+      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
+      - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
+
+>>>>>>> Stashed changes
   - name: 'ourSupport' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'Our Support' # Used in the UI
     label_singular: 'Our Support' # Used in the UI, ie: "New Post"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -76,8 +76,6 @@ collections: # A list of collections the CMS should be able to edit
       - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
       - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
 
-<<<<<<< Updated upstream
-=======
   - name: 'theChildren' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'The Children' # Used in the UI
     label_singular: 'The Children' # Used in the UI, ie: "New Post"
@@ -108,7 +106,6 @@ collections: # A list of collections the CMS should be able to edit
       - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
       - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
 
->>>>>>> Stashed changes
   - name: 'ourSupport' # Used in routes, ie.: /admin/collections/:slug/edit
     label: 'Our Support' # Used in the UI
     label_singular: 'Our Support' # Used in the UI, ie: "New Post"


### PR DESCRIPTION
Probably need to change the name/label. 

 - name: 'theChildren' # Used in routes, ie.: /admin/collections/:slug/edit
    label: 'The Children' # Used in the UI
    label_singular: 'The Children' # Used in the UI, ie: "New Post"
    description: >
      This collection is for managing the stories of the children we represent. Each post can be stored as a separate document or grouped based on categories or dates.
    folder: '_theChildren'
    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
    summary: '{{title}} -- {{year}}/{{month}}/{{day}}'
    create: true # Allow users to create new documents in this collection
    fields: # The fields each document in this collection have
      - { label: 'Title', name: 'title', widget: 'string', tagname: 'h1' }
      - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
      - { name: 'gallery', widget: 'image', choose_url: true, media_library: {config: {multiple: true, max_files: 999}}}
      - { name: 'post', widget: relation, collection: blogPost, multiple: true, search_fields: [ "title" ], display_fields: [ "title" ], value_field: "{{slug}}"}
      

- [x] Added the childrens collection

- [ ]  Approved?
